### PR TITLE
Match for variable definition highlighting

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -382,6 +382,9 @@ hi def link     goTypeName          Type
 hi def link     goTypeDecl          Keyword
 hi def link     goDeclType          Keyword
 
+" Variable Declarations
+syn match goVarDef /\w\+\(,\s*\w+\)*\s*\ze:=/
+
 " Build Constraints
 if g:go_highlight_build_constraints != 0
   syn match   goBuildKeyword      display contained "+build"

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -383,7 +383,7 @@ hi def link     goTypeDecl          Keyword
 hi def link     goDeclType          Keyword
 
 " Variable Declarations
-syn match goVarDef /\w\+\(,\s*\w+\)*\s*\ze:=/
+syn match goVarDefs /\w\+\(,\s*\w+\)*\s*\ze:=/
 
 " Build Constraints
 if g:go_highlight_build_constraints != 0


### PR DESCRIPTION
This adds a match for variable definitions (without the operator), such as:

    foo := ...
    foo, bar := ...

These definitions are highlighted in Sublime as well, and I've grown used to it.